### PR TITLE
Multi-Currency Regional Pricing

### DIFF
--- a/lib/compost_state.dart
+++ b/lib/compost_state.dart
@@ -4,14 +4,19 @@ import '../services/persistence_manager.dart';
 import '../data/compost_components_data.dart';
 import './models/price_model.dart';
 import '../models/availability_model.dart';
+import '../constants/currency_constants.dart';
 
 class CompostState extends ChangeNotifier {
   final PersistenceManager persistenceManager;
   List<CompostComponent> components = [];
+  String _selectedCurrency = CurrencyConstants.defaultCurrency;
 
   CompostState(this.persistenceManager) {
     _loadSavedComponents();
+    _loadSelectedCurrency();
   }
+
+  String get selectedCurrency => _selectedCurrency;
 
   void _loadSavedComponents() async {
     final savedComponents = await persistenceManager.getSavedComponents();
@@ -21,6 +26,22 @@ class CompostState extends ChangeNotifier {
       components = CompostComponentsData.components;
     }
     notifyListeners();
+  }
+
+  void _loadSelectedCurrency() async {
+    final savedCurrency = await persistenceManager.getSelectedCurrency();
+    if (savedCurrency != null && CurrencyConstants.isCurrencySupported(savedCurrency)) {
+      _selectedCurrency = savedCurrency;
+      notifyListeners();
+    }
+  }
+
+  void setSelectedCurrency(String currency) async {
+    if (CurrencyConstants.isCurrencySupported(currency)) {
+      _selectedCurrency = currency;
+      await persistenceManager.setSelectedCurrency(currency);
+      notifyListeners();
+    }
   }
 
   void updateComponent(CompostComponent updatedComponent) {
@@ -40,15 +61,17 @@ class CompostState extends ChangeNotifier {
   }
 
   // Helper method to update price
-  void updateComponentPrice(String componentName, double newPrice) {
+  void updateComponentPrice(String componentName, double newPrice, {String currency = 'CFA'}) {
     final index =
         components.indexWhere((comp) => comp.getName() == componentName);
     if (index != -1) {
       final component = components[index];
 
-      final updatedPrice = Price(
-        pricePerTon: newPrice.round(),
-      );
+      // Use existing price or create new one, then set regional price
+      final currentPrice = component.price ?? Price(pricePerTon: 0);
+      final updatedPrice = currency == 'CFA' 
+          ? currentPrice.updateCFAPrice(newPrice)  // Preserve regional prices when updating CFA
+          : currentPrice.withRegionalPrice(currency, newPrice);  // Set regional price
 
       final updatedComponent = CompostComponent(
         id: component.id,

--- a/lib/constants/currency_constants.dart
+++ b/lib/constants/currency_constants.dart
@@ -1,0 +1,94 @@
+class CurrencyConstants {
+  // Base currency is CFA (rate = 1.0)
+  static const Map<String, Map<String, dynamic>> currencies = {
+    'CFA': {
+      'symbol': 'FCFA',
+      'rate': 1.0,
+      'name': 'West African CFA Franc',
+      'decimalPlaces': 0,
+    },
+    'USD': {
+      'symbol': '\$',
+      'rate': 0.0016,
+      'name': 'US Dollar',
+      'decimalPlaces': 2,
+    },
+    'EUR': {
+      'symbol': '€',
+      'rate': 0.0015,
+      'name': 'Euro',
+      'decimalPlaces': 2,
+    },
+    'GBP': {
+      'symbol': '£',
+      'rate': 0.0013,
+      'name': 'British Pound',
+      'decimalPlaces': 2,
+    },
+    'MWK': {
+      'symbol': 'MWK',
+      'rate': 1.75,
+      'name': 'Malawian Kwacha',
+      'decimalPlaces': 0,
+    },
+    'NGN': {
+      'symbol': '₦',
+      'rate': 1.33,
+      'name': 'Nigerian Naira',
+      'decimalPlaces': 0,
+    },
+    'GHS': {
+      'symbol': '₵',
+      'rate': 0.019,
+      'name': 'Ghanaian Cedi',
+      'decimalPlaces': 2,
+    },
+  };
+
+  static const String defaultCurrency = 'CFA';
+
+  /// Convert price from CFA (base currency) to target currency
+  static double convertFromCFA(double cfaPrice, String toCurrency) {
+    if (!currencies.containsKey(toCurrency)) {
+      throw ArgumentError('Currency $toCurrency not supported');
+    }
+    return cfaPrice * currencies[toCurrency]!['rate'];
+  }
+
+  /// Convert price from any currency back to CFA
+  static double convertToCFA(double price, String fromCurrency) {
+    if (!currencies.containsKey(fromCurrency)) {
+      throw ArgumentError('Currency $fromCurrency not supported');
+    }
+    return price / currencies[fromCurrency]!['rate'];
+  }
+
+  /// Format price with currency symbol and appropriate decimal places
+  static String formatPrice(double price, String currency) {
+    if (!currencies.containsKey(currency)) {
+      throw ArgumentError('Currency $currency not supported');
+    }
+    
+    final currencyData = currencies[currency]!;
+    final symbol = currencyData['symbol'];
+    final decimalPlaces = currencyData['decimalPlaces'];
+    
+    return '$symbol ${price.toStringAsFixed(decimalPlaces)}';
+  }
+
+  /// Get currency symbol
+  static String getCurrencySymbol(String currency) {
+    return currencies[currency]?['symbol'] ?? '';
+  }
+
+
+  /// Get list of all supported currency codes
+  static List<String> getSupportedCurrencies() {
+    return currencies.keys.toList();
+  }
+
+  /// Check if currency is supported
+  static bool isCurrencySupported(String currency) {
+    return currencies.containsKey(currency);
+  }
+}

--- a/lib/generated/intl/messages_ar.dart
+++ b/lib/generated/intl/messages_ar.dart
@@ -208,6 +208,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "غطي بقايا الطعام بمواد بنية",
     ),
     "cowDung": MessageLookupByLibrary.simpleMessage("روث البقر"),
+    "currency": MessageLookupByLibrary.simpleMessage("العملة"),
     "currencyFCFA": MessageLookupByLibrary.simpleMessage("فرنك إفريقي"),
     "day1": MessageLookupByLibrary.simpleMessage("اليوم 1"),
     "day25": MessageLookupByLibrary.simpleMessage("اليوم 25"),

--- a/lib/generated/intl/messages_ar.dart
+++ b/lib/generated/intl/messages_ar.dart
@@ -9,7 +9,6 @@
 // ignore_for_file:annotate_overrides,prefer_generic_function_type_aliases
 // ignore_for_file:unused_import, file_names, avoid_escaping_inner_quotes
 // ignore_for_file:unnecessary_string_interpolations, unnecessary_string_escapes
-// coverage:ignore-start
 
 import 'package:intl/intl.dart';
 import 'package:intl/message_lookup_by_library.dart';
@@ -203,8 +202,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "coolingPhaseDays25to35": MessageLookupByLibrary.simpleMessage(
       "3. مرحلة التبريد (الأيام 25-35)",
     ),
-    "costFCFA": MessageLookupByLibrary.simpleMessage("التكلفة (فرنك إفريقي)"),
     "costPerTon": MessageLookupByLibrary.simpleMessage("التكلفة/طن"),
+    "costTotal": MessageLookupByLibrary.simpleMessage("التكلفة الإجمالية"),
     "coverFoodScrapsWithBrowns": MessageLookupByLibrary.simpleMessage(
       "غطي بقايا الطعام بمواد بنية",
     ),
@@ -511,4 +510,3 @@ class MessageLookup extends MessageLookupByLibrary {
         ),
   };
 }
-// coverage:ignore-end

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -210,6 +210,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Cover food scraps with browns",
     ),
     "cowDung": MessageLookupByLibrary.simpleMessage("Cow dung"),
+    "currency": MessageLookupByLibrary.simpleMessage("Currency"),
     "currencyFCFA": MessageLookupByLibrary.simpleMessage("FCFA"),
     "day1": MessageLookupByLibrary.simpleMessage("Day 1"),
     "day25": MessageLookupByLibrary.simpleMessage("Day 25"),

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -204,8 +204,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "coolingPhaseDays25to35": MessageLookupByLibrary.simpleMessage(
       "3. Cooling Phase (Days 25-35)",
     ),
-    "costFCFA": MessageLookupByLibrary.simpleMessage("Cost (FCFA)"),
     "costPerTon": MessageLookupByLibrary.simpleMessage("Cost/Ton"),
+    "costTotal": MessageLookupByLibrary.simpleMessage("Total Cost"),
     "coverFoodScrapsWithBrowns": MessageLookupByLibrary.simpleMessage(
       "Cover food scraps with browns",
     ),

--- a/lib/generated/intl/messages_fr.dart
+++ b/lib/generated/intl/messages_fr.dart
@@ -9,7 +9,6 @@
 // ignore_for_file:annotate_overrides,prefer_generic_function_type_aliases
 // ignore_for_file:unused_import, file_names, avoid_escaping_inner_quotes
 // ignore_for_file:unnecessary_string_interpolations, unnecessary_string_escapes
-// coverage:ignore-start
 
 import 'package:intl/intl.dart';
 import 'package:intl/message_lookup_by_library.dart';
@@ -218,8 +217,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "coolingPhaseDays25to35": MessageLookupByLibrary.simpleMessage(
       "3. Phase de Refroidissement (Jours 25-35)",
     ),
-    "costFCFA": MessageLookupByLibrary.simpleMessage("Coût (FCFA)"),
     "costPerTon": MessageLookupByLibrary.simpleMessage("Coût/tonne"),
+    "costTotal": MessageLookupByLibrary.simpleMessage("Coût Total"),
     "coverFoodScrapsWithBrowns": MessageLookupByLibrary.simpleMessage(
       "Couvrir les restes alimentaires avec des matières brunes",
     ),
@@ -536,4 +535,3 @@ class MessageLookup extends MessageLookupByLibrary {
         ),
   };
 }
-// coverage:ignore-end

--- a/lib/generated/intl/messages_fr.dart
+++ b/lib/generated/intl/messages_fr.dart
@@ -223,6 +223,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Couvrir les restes alimentaires avec des matières brunes",
     ),
     "cowDung": MessageLookupByLibrary.simpleMessage("Bouse de vache"),
+    "currency": MessageLookupByLibrary.simpleMessage("Devise"),
     "currencyFCFA": MessageLookupByLibrary.simpleMessage("FCFA"),
     "day1": MessageLookupByLibrary.simpleMessage("Jour 1"),
     "day25": MessageLookupByLibrary.simpleMessage("Jour 25"),

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -605,6 +605,16 @@ class S {
     );
   }
 
+  /// `Currency`
+  String get currency {
+    return Intl.message(
+      'Currency',
+      name: 'currency',
+      desc: 'Label for currency selection',
+      args: [],
+    );
+  }
+
   /// `FCFA`
   String get currencyFCFA {
     return Intl.message(

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -276,12 +276,12 @@ class S {
     );
   }
 
-  /// `Cost (FCFA)`
-  String get costFCFA {
+  /// `Total Cost`
+  String get costTotal {
     return Intl.message(
-      'Cost (FCFA)',
-      name: 'costFCFA',
-      desc: 'Column header for cost in FCFA currency',
+      'Total Cost',
+      name: 'costTotal',
+      desc: 'Column header for total cost',
       args: [],
     );
   }

--- a/lib/l10n/intl_ar.arb
+++ b/lib/l10n/intl_ar.arb
@@ -106,9 +106,9 @@
     "@component": {
         "description": "Single component label for table header"
     },
-    "costFCFA": "التكلفة (فرنك إفريقي)",
-    "@costFCFA": {
-        "description": "Column header for cost in FCFA currency"
+    "costTotal": "التكلفة الإجمالية",
+    "@costTotal": {
+        "description": "Column header for total cost"
     },
     "percentage": "{value} (%)",
     "@percentage": {

--- a/lib/l10n/intl_ar.arb
+++ b/lib/l10n/intl_ar.arb
@@ -242,6 +242,10 @@
     "@costPerTon": {
         "description": "Label for cost per unit input field"
     },
+    "currency": "العملة",
+    "@currency": {
+        "description": "Label for currency selection"
+    },
     "currencyFCFA": "فرنك إفريقي",
     "@currencyFCFA": {
         "description": "Currency label for FCFA"

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -106,9 +106,9 @@
     "@component": {
         "description": "Single component label for table header"
     },
-    "costFCFA": "Cost (FCFA)",
-    "@costFCFA": {
-        "description": "Column header for cost in FCFA currency"
+    "costTotal": "Total Cost",
+    "@costTotal": {
+        "description": "Column header for total cost"
     },
     "percentage": "{value} (%)",
     "@percentage": {

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -242,6 +242,10 @@
     "@costPerTon": {
         "description": "Label for cost per unit input field"
     },
+    "currency": "Currency",
+    "@currency": {
+        "description": "Label for currency selection"
+    },
     "currencyFCFA": "FCFA",
     "@currencyFCFA": {
         "description": "Currency label for FCFA"

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -106,9 +106,9 @@
     "@component": {
         "description": "Single component label for table header"
     },
-    "costFCFA": "Coût (FCFA)",
-    "@costFCFA": {
-        "description": "Column header for cost in FCFA currency"
+    "costTotal": "Coût Total",
+    "@costTotal": {
+        "description": "Column header for total cost"
     },
     "percentage": "{value} (%)",
     "@percentage": {

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -242,6 +242,10 @@
     "@costPerTon": {
         "description": "Label for cost per unit input field"
     },
+    "currency": "Devise",
+    "@currency": {
+        "description": "Label for currency selection"
+    },
     "currencyFCFA": "FCFA",
     "@currencyFCFA": {
         "description": "Currency label for FCFA"

--- a/lib/models/price_model.dart
+++ b/lib/models/price_model.dart
@@ -1,11 +1,76 @@
+import '../constants/currency_constants.dart';
+
 class Price {
-  final int pricePerTon;
+  final double pricePerTon; // Base CFA price
+  final Map<String, double>? regionalPrices; // Optional regional overrides
 
   Price({
     required this.pricePerTon,
+    this.regionalPrices,
   });
 
-  double calculatePrice(double amount) {
-    return (pricePerTon / 1000) * amount;
+  /// Get price for specific currency (regional if available, converted if not)
+  double getPriceForCurrency(String currency) {
+    if (currency == 'CFA') return pricePerTon;
+    if (regionalPrices?.containsKey(currency) == true) {
+      return regionalPrices![currency]!; // Use regional price
+    }
+    return CurrencyConstants.convertFromCFA(pricePerTon, currency); // Fallback to conversion
+  }
+
+  /// Set regional price for specific currency
+  Price withRegionalPrice(String currency, double price) {
+    final newRegionalPrices = Map<String, double>.from(regionalPrices ?? {});
+    
+    if (currency == 'CFA') {
+      // If setting CFA, update base price and remove from regional
+      newRegionalPrices.remove('CFA');
+      return Price(
+        pricePerTon: price, 
+        regionalPrices: newRegionalPrices.isEmpty ? null : newRegionalPrices,
+      );
+    }
+    
+    newRegionalPrices[currency] = price;
+    return Price(
+      pricePerTon: pricePerTon, 
+      regionalPrices: newRegionalPrices,
+    );
+  }
+
+  /// Clear regional price to fall back to CFA conversion
+  Price clearRegionalPrice(String currency) {
+    if (currency == 'CFA' || regionalPrices == null) return this;
+    
+    final newRegional = Map<String, double>.from(regionalPrices!);
+    newRegional.remove(currency);
+    
+    return Price(
+      pricePerTon: pricePerTon,
+      regionalPrices: newRegional.isEmpty ? null : newRegional,
+    );
+  }
+
+  /// Check if a currency has a regional override
+  bool hasRegionalPrice(String currency) {
+    return currency != 'CFA' && regionalPrices?.containsKey(currency) == true;
+  }
+
+  /// Check if a currency is "untouched" (using CFA conversion, not regional override)
+  bool isUntouchedCurrency(String currency) {
+    return currency != 'CFA' && !hasRegionalPrice(currency);
+  }
+
+  /// Update CFA price and preserve regional overrides
+  Price updateCFAPrice(double newCfaPrice) {
+    return Price(
+      pricePerTon: newCfaPrice,
+      regionalPrices: regionalPrices, // Keep all regional overrides unchanged
+    );
+  }
+
+  double calculatePrice(double amount, {String currency = 'CFA'}) {
+    final price = getPriceForCurrency(currency);
+    return (price / 1000) * amount;
   }
 }

--- a/lib/screens/price_page.dart
+++ b/lib/screens/price_page.dart
@@ -4,9 +4,68 @@ import '../compost_state.dart';
 import '../models/compost_component_model.dart';
 import '../generated/l10n.dart';
 import '../widgets/edit_availability_dialog.dart';
+import '../widgets/currency_selector.dart';
+import '../constants/currency_constants.dart';
 
-class PricesPage extends StatelessWidget {
+class PricesPage extends StatefulWidget {
   const PricesPage({super.key});
+
+  @override
+  State<PricesPage> createState() => _PricesPageState();
+}
+
+class _PricesPageState extends State<PricesPage> {
+  final Map<String, TextEditingController> _controllers = {};
+
+  @override
+  void dispose() {
+    for (var controller in _controllers.values) {
+      controller.dispose();
+    }
+    super.dispose();
+  }
+
+  /// Update controller text if it differs from expected value
+  void _updateControllerIfNeeded(String key, double newPrice, int decimalPlaces) {
+    if (_controllers.containsKey(key)) {
+      final expectedText = newPrice.toStringAsFixed(decimalPlaces);
+      if (_controllers[key]!.text != expectedText) {
+        _controllers[key]!.text = expectedText;
+      }
+    }
+  }
+
+  /// Update all controllers for untouched currencies when CFA base price changes
+  void _updateUntouchedControllers(List<CompostComponent> components, String currentCurrency) {
+    for (var component in components) {
+      for (var currency in CurrencyConstants.getSupportedCurrencies()) {
+        if (currency != currentCurrency && component.price?.isUntouchedCurrency(currency) == true) {
+          final key = '${component.getName()}_$currency';
+          final price = component.price!.getPriceForCurrency(currency);
+          final decimalPlaces = CurrencyConstants.currencies[currency]!['decimalPlaces'];
+          _updateControllerIfNeeded(key, price, decimalPlaces);
+        }
+      }
+    }
+  }
+
+  TextEditingController _getController(String componentName, CompostComponent component, String currency) {
+    final key = '${componentName}_$currency';
+    final price = component.price?.getPriceForCurrency(currency) ?? 0.0;
+    final decimalPlaces = CurrencyConstants.currencies[currency]!['decimalPlaces'];
+    
+    // Always ensure controller has current value
+    if (!_controllers.containsKey(key)) {
+      _controllers[key] = TextEditingController(
+        text: price.toStringAsFixed(decimalPlaces),
+      );
+    } else {
+      // Update existing controller if the price has changed
+      _updateControllerIfNeeded(key, price, decimalPlaces);
+    }
+    
+    return _controllers[key]!;
+  }
 
   Widget _buildSectionTitle(String title) {
     return Padding(
@@ -56,27 +115,50 @@ class PricesPage extends StatelessWidget {
           ),
           trailing: SizedBox(
             width: 120,
-            child: TextFormField(
-              initialValue: (component.price?.pricePerTon ?? 0).toString(),
-              decoration: InputDecoration(
-                labelText: S.of(context).costPerTon,
-                suffixText: S.of(context).currencyFCFA,
-                isDense: true,
-              ),
-              keyboardType:
-                  const TextInputType.numberWithOptions(decimal: true),
-              onChanged: (value) {
-                final newPrice = double.tryParse(value);
-                if (newPrice != null) {
-                  compostState.updateComponentPrice(
-                      component.getName(), newPrice);
-                }
-              },
-            ),
+            child: _buildPriceInput(component, compostState, context),
           ),
         ),
         const Divider(),
       ],
+    );
+  }
+
+  Widget _buildPriceInput(
+    CompostComponent component,
+    CompostState compostState,
+    BuildContext context,
+  ) {
+    final controller = _getController(
+      component.getName(),
+      component,
+      compostState.selectedCurrency,
+    );
+    
+    return TextFormField(
+      key: ValueKey('${component.getName()}_${compostState.selectedCurrency}'),
+      controller: controller,
+      decoration: InputDecoration(
+        labelText: S.of(context).costPerTon,
+        suffixText: CurrencyConstants.getCurrencySymbol(compostState.selectedCurrency),
+        isDense: true,
+      ),
+      keyboardType: const TextInputType.numberWithOptions(decimal: true),
+      onChanged: (value) {
+        final newPrice = double.tryParse(value);
+        if (newPrice != null) {
+          // Save the price in the selected currency (regional pricing)
+          compostState.updateComponentPrice(
+            component.getName(),
+            newPrice,
+            currency: compostState.selectedCurrency,
+          );
+          
+          // If this is a CFA price change, update controllers for untouched currencies
+          if (compostState.selectedCurrency == 'CFA') {
+            _updateUntouchedControllers(compostState.components, compostState.selectedCurrency);
+          }
+        }
+      },
     );
   }
 
@@ -108,6 +190,8 @@ class PricesPage extends StatelessWidget {
 
           return ListView(
             children: [
+              const CurrencySelector(),
+              const Divider(),
               _buildSectionTitle(S.of(context).allIngredients),
               ...components.map((component) =>
                   _buildComponentTile(component, compostState, context)),

--- a/lib/services/persistence_manager.dart
+++ b/lib/services/persistence_manager.dart
@@ -12,6 +12,7 @@ class PersistenceManager {
   static const String _recipeKey = 'current_recipe';
   static const String _recipesHistoryKey = 'recipes_history';
   static const String _componentsKey = 'components_data';
+  static const String _selectedCurrencyKey = 'selected_currency';
 
   static Future<void> init() async {
     _prefs = await SharedPreferences.getInstance();
@@ -92,6 +93,15 @@ class PersistenceManager {
     return await _prefs?.clear() ?? false;
   }
 
+  // Currency Management
+  Future<bool> setSelectedCurrency(String currency) async {
+    return await _prefs?.setString(_selectedCurrencyKey, currency) ?? false;
+  }
+
+  Future<String?> getSelectedCurrency() async {
+    return _prefs?.getString(_selectedCurrencyKey);
+  }
+
   // JSON Conversion Helpers
   Map<String, dynamic> _recipeToJson(Recipe recipe) {
     return {
@@ -135,6 +145,7 @@ class PersistenceManager {
       'price': component.price != null
           ? {
               'pricePerTon': component.price!.pricePerTon,
+              'regionalPrices': component.price!.regionalPrices,
             }
           : null,
       'sources': component.sources,
@@ -158,7 +169,14 @@ class PersistenceManager {
       ),
       price: json['price'] != null
           ? Price(
-              pricePerTon: json['price']['pricePerTon'],
+              pricePerTon: json['price']['pricePerTon'].toDouble(),
+              regionalPrices: json['price']['regionalPrices'] != null
+                  ? Map<String, double>.from(
+                      json['price']['regionalPrices'].map(
+                        (key, value) => MapEntry(key, value.toDouble()),
+                      ),
+                    )
+                  : null,
             )
           : null,
       sources: List<String>.from(json['sources']),

--- a/lib/widgets/component_table.dart
+++ b/lib/widgets/component_table.dart
@@ -41,7 +41,7 @@ class ComponentTable extends StatelessWidget {
       ColumnDefinition(label: S.current.water, key: 'water'),
       if (items.any((item) => item.component.price != null))
         ColumnDefinition(
-            label: S.current.costFCFA, key: 'cost', decimalPlaces: 2),
+            label: S.current.costTotal, key: 'cost', decimalPlaces: 2),
     ];
   }
 

--- a/lib/widgets/currency_selector.dart
+++ b/lib/widgets/currency_selector.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../constants/currency_constants.dart';
+import '../compost_state.dart';
+import '../generated/l10n.dart';
+
+class CurrencySelector extends StatelessWidget {
+  const CurrencySelector({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<CompostState>(
+      builder: (context, compostState, child) {
+        return Container(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                S.of(context).currency,
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              const SizedBox(width: 12),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+                decoration: BoxDecoration(
+                  border: Border.all(color: Colors.grey.shade300),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: DropdownButtonHideUnderline(
+                  child: DropdownButton<String>(
+                    value: compostState.selectedCurrency,
+                    onChanged: (String? newCurrency) {
+                      if (newCurrency != null) {
+                        compostState.setSelectedCurrency(newCurrency);
+                      }
+                    },
+                    items: CurrencyConstants.getSupportedCurrencies()
+                        .map<DropdownMenuItem<String>>((String currency) {
+                      final symbol = CurrencyConstants.getCurrencySymbol(currency);
+                      return DropdownMenuItem<String>(
+                        value: currency,
+                        child: Text(
+                          '$currency ($symbol)',
+                          style: const TextStyle(fontSize: 14),
+                        ),
+                      );
+                    }).toList(),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/widgets/nutrient_totals_table.dart
+++ b/lib/widgets/nutrient_totals_table.dart
@@ -121,7 +121,7 @@ class NutrientTotalsTable extends StatelessWidget {
             ),
           ),
           if (components.any((comp) => comp.component.price != null))
-            DataColumn(label: Text(S.of(context).totalCostFCFA)),
+            DataColumn(label: Text(S.of(context).costTotal)),
         ],
         rows: [
           DataRow(

--- a/test/compost_state_test.mocks.dart
+++ b/test/compost_state_test.mocks.dart
@@ -106,4 +106,20 @@ class MockPersistenceManager extends _i1.Mock
             returnValue: _i3.Future<bool>.value(false),
           )
           as _i3.Future<bool>);
+
+  @override
+  _i3.Future<bool> setSelectedCurrency(String? currency) =>
+      (super.noSuchMethod(
+            Invocation.method(#setSelectedCurrency, [currency]),
+            returnValue: _i3.Future<bool>.value(false),
+          )
+          as _i3.Future<bool>);
+
+  @override
+  _i3.Future<String?> getSelectedCurrency() =>
+      (super.noSuchMethod(
+            Invocation.method(#getSelectedCurrency, []),
+            returnValue: _i3.Future<String?>.value(),
+          )
+          as _i3.Future<String?>);
 }

--- a/test/main_test.mocks.dart
+++ b/test/main_test.mocks.dart
@@ -4,14 +4,15 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i3;
-import 'dart:ui' as _i8;
+import 'dart:ui' as _i9;
 
 import 'package:compostapp/compost_state.dart' as _i6;
-import 'package:compostapp/models/availability_model.dart' as _i7;
+import 'package:compostapp/models/availability_model.dart' as _i8;
 import 'package:compostapp/models/compost_component_model.dart' as _i5;
 import 'package:compostapp/models/recipe_model.dart' as _i4;
 import 'package:compostapp/services/persistence_manager.dart' as _i2;
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:mockito/src/dummies.dart' as _i7;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -115,6 +116,22 @@ class MockPersistenceManager extends _i1.Mock
             returnValue: _i3.Future<bool>.value(false),
           )
           as _i3.Future<bool>);
+
+  @override
+  _i3.Future<bool> setSelectedCurrency(String? currency) =>
+      (super.noSuchMethod(
+            Invocation.method(#setSelectedCurrency, [currency]),
+            returnValue: _i3.Future<bool>.value(false),
+          )
+          as _i3.Future<bool>);
+
+  @override
+  _i3.Future<String?> getSelectedCurrency() =>
+      (super.noSuchMethod(
+            Invocation.method(#getSelectedCurrency, []),
+            returnValue: _i3.Future<String?>.value(),
+          )
+          as _i3.Future<String?>);
 }
 
 /// A class which mocks [CompostState].
@@ -151,9 +168,26 @@ class MockCompostState extends _i1.Mock implements _i6.CompostState {
   );
 
   @override
+  String get selectedCurrency =>
+      (super.noSuchMethod(
+            Invocation.getter(#selectedCurrency),
+            returnValue: _i7.dummyValue<String>(
+              this,
+              Invocation.getter(#selectedCurrency),
+            ),
+          )
+          as String);
+
+  @override
   bool get hasListeners =>
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);
+
+  @override
+  void setSelectedCurrency(String? currency) => super.noSuchMethod(
+    Invocation.method(#setSelectedCurrency, [currency]),
+    returnValueForMissingStub: null,
+  );
 
   @override
   void updateComponent(_i5.CompostComponent? updatedComponent) =>
@@ -171,16 +205,23 @@ class MockCompostState extends _i1.Mock implements _i6.CompostState {
           as List<_i5.CompostComponent>);
 
   @override
-  void updateComponentPrice(String? componentName, double? newPrice) =>
-      super.noSuchMethod(
-        Invocation.method(#updateComponentPrice, [componentName, newPrice]),
-        returnValueForMissingStub: null,
-      );
+  void updateComponentPrice(
+    String? componentName,
+    double? newPrice, {
+    String? currency = 'CFA',
+  }) => super.noSuchMethod(
+    Invocation.method(
+      #updateComponentPrice,
+      [componentName, newPrice],
+      {#currency: currency},
+    ),
+    returnValueForMissingStub: null,
+  );
 
   @override
   void updateComponentAvailability(
     String? componentId,
-    _i7.AvailabilityPeriod? newAvailability,
+    _i8.AvailabilityPeriod? newAvailability,
   ) => super.noSuchMethod(
     Invocation.method(#updateComponentAvailability, [
       componentId,
@@ -190,13 +231,13 @@ class MockCompostState extends _i1.Mock implements _i6.CompostState {
   );
 
   @override
-  void addListener(_i8.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i9.VoidCallback? listener) => super.noSuchMethod(
     Invocation.method(#addListener, [listener]),
     returnValueForMissingStub: null,
   );
 
   @override
-  void removeListener(_i8.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i9.VoidCallback? listener) => super.noSuchMethod(
     Invocation.method(#removeListener, [listener]),
     returnValueForMissingStub: null,
   );

--- a/test/screens/home_screen_test.mocks.dart
+++ b/test/screens/home_screen_test.mocks.dart
@@ -4,14 +4,15 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i3;
-import 'dart:ui' as _i8;
+import 'dart:ui' as _i9;
 
 import 'package:compostapp/compost_state.dart' as _i6;
-import 'package:compostapp/models/availability_model.dart' as _i7;
+import 'package:compostapp/models/availability_model.dart' as _i8;
 import 'package:compostapp/models/compost_component_model.dart' as _i5;
 import 'package:compostapp/models/recipe_model.dart' as _i4;
 import 'package:compostapp/services/persistence_manager.dart' as _i2;
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:mockito/src/dummies.dart' as _i7;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -115,6 +116,22 @@ class MockPersistenceManager extends _i1.Mock
             returnValue: _i3.Future<bool>.value(false),
           )
           as _i3.Future<bool>);
+
+  @override
+  _i3.Future<bool> setSelectedCurrency(String? currency) =>
+      (super.noSuchMethod(
+            Invocation.method(#setSelectedCurrency, [currency]),
+            returnValue: _i3.Future<bool>.value(false),
+          )
+          as _i3.Future<bool>);
+
+  @override
+  _i3.Future<String?> getSelectedCurrency() =>
+      (super.noSuchMethod(
+            Invocation.method(#getSelectedCurrency, []),
+            returnValue: _i3.Future<String?>.value(),
+          )
+          as _i3.Future<String?>);
 }
 
 /// A class which mocks [CompostState].
@@ -151,9 +168,26 @@ class MockCompostState extends _i1.Mock implements _i6.CompostState {
   );
 
   @override
+  String get selectedCurrency =>
+      (super.noSuchMethod(
+            Invocation.getter(#selectedCurrency),
+            returnValue: _i7.dummyValue<String>(
+              this,
+              Invocation.getter(#selectedCurrency),
+            ),
+          )
+          as String);
+
+  @override
   bool get hasListeners =>
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);
+
+  @override
+  void setSelectedCurrency(String? currency) => super.noSuchMethod(
+    Invocation.method(#setSelectedCurrency, [currency]),
+    returnValueForMissingStub: null,
+  );
 
   @override
   void updateComponent(_i5.CompostComponent? updatedComponent) =>
@@ -171,16 +205,23 @@ class MockCompostState extends _i1.Mock implements _i6.CompostState {
           as List<_i5.CompostComponent>);
 
   @override
-  void updateComponentPrice(String? componentName, double? newPrice) =>
-      super.noSuchMethod(
-        Invocation.method(#updateComponentPrice, [componentName, newPrice]),
-        returnValueForMissingStub: null,
-      );
+  void updateComponentPrice(
+    String? componentName,
+    double? newPrice, {
+    String? currency = 'CFA',
+  }) => super.noSuchMethod(
+    Invocation.method(
+      #updateComponentPrice,
+      [componentName, newPrice],
+      {#currency: currency},
+    ),
+    returnValueForMissingStub: null,
+  );
 
   @override
   void updateComponentAvailability(
     String? componentId,
-    _i7.AvailabilityPeriod? newAvailability,
+    _i8.AvailabilityPeriod? newAvailability,
   ) => super.noSuchMethod(
     Invocation.method(#updateComponentAvailability, [
       componentId,
@@ -190,13 +231,13 @@ class MockCompostState extends _i1.Mock implements _i6.CompostState {
   );
 
   @override
-  void addListener(_i8.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i9.VoidCallback? listener) => super.noSuchMethod(
     Invocation.method(#addListener, [listener]),
     returnValueForMissingStub: null,
   );
 
   @override
-  void removeListener(_i8.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i9.VoidCallback? listener) => super.noSuchMethod(
     Invocation.method(#removeListener, [listener]),
     returnValueForMissingStub: null,
   );

--- a/test/screens/price_page_test.mocks.dart
+++ b/test/screens/price_page_test.mocks.dart
@@ -3,13 +3,14 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:ui' as _i6;
+import 'dart:ui' as _i7;
 
 import 'package:compostapp/compost_state.dart' as _i3;
-import 'package:compostapp/models/availability_model.dart' as _i5;
+import 'package:compostapp/models/availability_model.dart' as _i6;
 import 'package:compostapp/models/compost_component_model.dart' as _i4;
 import 'package:compostapp/services/persistence_manager.dart' as _i2;
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:mockito/src/dummies.dart' as _i5;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -65,9 +66,26 @@ class MockCompostState extends _i1.Mock implements _i3.CompostState {
   );
 
   @override
+  String get selectedCurrency =>
+      (super.noSuchMethod(
+            Invocation.getter(#selectedCurrency),
+            returnValue: _i5.dummyValue<String>(
+              this,
+              Invocation.getter(#selectedCurrency),
+            ),
+          )
+          as String);
+
+  @override
   bool get hasListeners =>
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);
+
+  @override
+  void setSelectedCurrency(String? currency) => super.noSuchMethod(
+    Invocation.method(#setSelectedCurrency, [currency]),
+    returnValueForMissingStub: null,
+  );
 
   @override
   void updateComponent(_i4.CompostComponent? updatedComponent) =>
@@ -85,16 +103,23 @@ class MockCompostState extends _i1.Mock implements _i3.CompostState {
           as List<_i4.CompostComponent>);
 
   @override
-  void updateComponentPrice(String? componentName, double? newPrice) =>
-      super.noSuchMethod(
-        Invocation.method(#updateComponentPrice, [componentName, newPrice]),
-        returnValueForMissingStub: null,
-      );
+  void updateComponentPrice(
+    String? componentName,
+    double? newPrice, {
+    String? currency = 'CFA',
+  }) => super.noSuchMethod(
+    Invocation.method(
+      #updateComponentPrice,
+      [componentName, newPrice],
+      {#currency: currency},
+    ),
+    returnValueForMissingStub: null,
+  );
 
   @override
   void updateComponentAvailability(
     String? componentId,
-    _i5.AvailabilityPeriod? newAvailability,
+    _i6.AvailabilityPeriod? newAvailability,
   ) => super.noSuchMethod(
     Invocation.method(#updateComponentAvailability, [
       componentId,
@@ -104,13 +129,13 @@ class MockCompostState extends _i1.Mock implements _i3.CompostState {
   );
 
   @override
-  void addListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i7.VoidCallback? listener) => super.noSuchMethod(
     Invocation.method(#addListener, [listener]),
     returnValueForMissingStub: null,
   );
 
   @override
-  void removeListener(_i6.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i7.VoidCallback? listener) => super.noSuchMethod(
     Invocation.method(#removeListener, [listener]),
     returnValueForMissingStub: null,
   );

--- a/test/screens/recipe_builder_page_test.mocks.dart
+++ b/test/screens/recipe_builder_page_test.mocks.dart
@@ -4,14 +4,15 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i3;
-import 'dart:ui' as _i8;
+import 'dart:ui' as _i9;
 
 import 'package:compostapp/compost_state.dart' as _i6;
-import 'package:compostapp/models/availability_model.dart' as _i7;
+import 'package:compostapp/models/availability_model.dart' as _i8;
 import 'package:compostapp/models/compost_component_model.dart' as _i5;
 import 'package:compostapp/models/recipe_model.dart' as _i4;
 import 'package:compostapp/services/persistence_manager.dart' as _i2;
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:mockito/src/dummies.dart' as _i7;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -115,6 +116,22 @@ class MockPersistenceManager extends _i1.Mock
             returnValue: _i3.Future<bool>.value(false),
           )
           as _i3.Future<bool>);
+
+  @override
+  _i3.Future<bool> setSelectedCurrency(String? currency) =>
+      (super.noSuchMethod(
+            Invocation.method(#setSelectedCurrency, [currency]),
+            returnValue: _i3.Future<bool>.value(false),
+          )
+          as _i3.Future<bool>);
+
+  @override
+  _i3.Future<String?> getSelectedCurrency() =>
+      (super.noSuchMethod(
+            Invocation.method(#getSelectedCurrency, []),
+            returnValue: _i3.Future<String?>.value(),
+          )
+          as _i3.Future<String?>);
 }
 
 /// A class which mocks [CompostState].
@@ -151,9 +168,26 @@ class MockCompostState extends _i1.Mock implements _i6.CompostState {
   );
 
   @override
+  String get selectedCurrency =>
+      (super.noSuchMethod(
+            Invocation.getter(#selectedCurrency),
+            returnValue: _i7.dummyValue<String>(
+              this,
+              Invocation.getter(#selectedCurrency),
+            ),
+          )
+          as String);
+
+  @override
   bool get hasListeners =>
       (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
           as bool);
+
+  @override
+  void setSelectedCurrency(String? currency) => super.noSuchMethod(
+    Invocation.method(#setSelectedCurrency, [currency]),
+    returnValueForMissingStub: null,
+  );
 
   @override
   void updateComponent(_i5.CompostComponent? updatedComponent) =>
@@ -171,16 +205,23 @@ class MockCompostState extends _i1.Mock implements _i6.CompostState {
           as List<_i5.CompostComponent>);
 
   @override
-  void updateComponentPrice(String? componentName, double? newPrice) =>
-      super.noSuchMethod(
-        Invocation.method(#updateComponentPrice, [componentName, newPrice]),
-        returnValueForMissingStub: null,
-      );
+  void updateComponentPrice(
+    String? componentName,
+    double? newPrice, {
+    String? currency = 'CFA',
+  }) => super.noSuchMethod(
+    Invocation.method(
+      #updateComponentPrice,
+      [componentName, newPrice],
+      {#currency: currency},
+    ),
+    returnValueForMissingStub: null,
+  );
 
   @override
   void updateComponentAvailability(
     String? componentId,
-    _i7.AvailabilityPeriod? newAvailability,
+    _i8.AvailabilityPeriod? newAvailability,
   ) => super.noSuchMethod(
     Invocation.method(#updateComponentAvailability, [
       componentId,
@@ -190,13 +231,13 @@ class MockCompostState extends _i1.Mock implements _i6.CompostState {
   );
 
   @override
-  void addListener(_i8.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i9.VoidCallback? listener) => super.noSuchMethod(
     Invocation.method(#addListener, [listener]),
     returnValueForMissingStub: null,
   );
 
   @override
-  void removeListener(_i8.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i9.VoidCallback? listener) => super.noSuchMethod(
     Invocation.method(#removeListener, [listener]),
     returnValueForMissingStub: null,
   );


### PR DESCRIPTION
Added multi-currency support with regional pricing for the compost calculator. Users can set independent prices for different markets while CFA remains the base currency.

Regional Pricing System
- [x] Enhanced Price model to store regional price overrides alongside CFA base price
- [x] CFA changes preserve existing regional overrides, only updating untouched currencies
- [x] Regional prices persist across app sessions

Currency Support
- [x] Added 7 currencies: CFA, USD, EUR, GBP, MWK, NGN, GHS
- [x] Currency selector dropdown with proper formatting and symbols
- [x] Updated column headers from "Cost (FCFA)" to "Total Cost"

Controller Management
- [x] Fixed TextFormField controllers to sync with currency changes
- [x] Smart controller caching prevents unnecessary recreations
- [x] Automatic updates for untouched currencies when CFA base price changes

We chose regional pricing over simple conversion to allow market-specific pricing flexibility. When CFA price changes, currencies with regional overrides stay unchanged while untouched currencies update to new converted values. This preserves user pricing decisions while maintaining CFA as the authoritative base.